### PR TITLE
remove "generate_wind_field_from_single_measurement" function

### DIFF
--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -611,21 +611,16 @@ def init_level2(level1):
 
 
 def init_auxiliary(level1, u10, wind_direction):
+    '''
+    WARNING: the function is descoped.
+    WARNING recommandation is to use:
+    seastar/performance/scene_generation/generate_constant_env_field(da: xr.DataArray, env: dict) -> xr.Dataset
+    '''
 
-    "A Dataset containing WindSpeed, WindDirection,"
-    "IncidenceAngleImage, LookDirection, Polarization"
-    "All matrix should be the same size"
-    "Polarization (1=VV; 2=HH)"
-
-    WindSpeed, WindDirection =\
-        seastar.performance.scene_generation\
-            .generate_wind_field_from_single_measurement(u10,
-                                                    wind_direction,
-                                                    level1)
-    aux = xr.Dataset()
-    aux['WindSpeed'] = WindSpeed
-    aux['WindDirection'] = WindDirection
-
+    aux = seastar.performance.scene_generation.generate_constant_env_field(
+        level1.isel(Antenna=0).IncidenceAngleImage, 
+        {'WindSpeed': u10, 'WindDirection': wind_direction})
+    
     return aux
 
 

--- a/seastar/performance/scene_generation.py
+++ b/seastar/performance/scene_generation.py
@@ -428,42 +428,6 @@ def generate_constant_env_field(da: xr.DataArray, env: dict) -> xr.Dataset:
     
     return(ds_env)
 
-def generate_wind_field_from_single_measurement(u10, wind_direction, da):
-    """
-    Generate 2D fields of wind velocity and direction.
-
-    Generate 2D fields of wind velocity u10 (m/s) and direction (degrees) in
-    wind convention from single observations.
-
-    Parameters
-    ----------
-    u10 : ``float``
-        Wind velocity at 10m above sea surface (m/s)
-    wind_direction : ``float``
-        Wind direction (degrees N) in wind convention
-    da : ``xarray.DataArray``
-        DataArray in form (shape, coords, dims) to return wind field in
-
-    Returns
-    -------
-    u10Image: ``xarray.DataArray``
-        2D field of u10 wind velocities (m/s)
-    WindDirectionImage : ``xarray.DataArray``
-        2D field of wind directions (degrees N)
-    """
-    wind_direction = np.mod(wind_direction, 360)
-    u10Image = xr.DataArray(
-        np.zeros(da.shape)
-        + u10,
-        coords=da.coords,
-        dims=da.dims)
-    WindDirectionImage = xr.DataArray(
-        np.zeros(da.shape)
-        + wind_direction,
-        coords=da.coords,
-        dims=da.dims)
-    return u10Image, WindDirectionImage
-
 
 def compute_truth_level1(
         inst: xr.Dataset, geo: xr.Dataset, gmf: dict, 


### PR DESCRIPTION
"seastar/performance/scene_generation/generate_wind_field_from_single_measurements" is only used in "seastar/oscar/level1/init_auxiliary". Replaced with the more generic "seastar/performance/scene_generation/generate_constant_env_field".

"init_auxiliary" is kept for continuity, but using the generic function. 
Init_auxiliary is used in out-of-date, not classified, notebooks: L2 noise effect comparison.ipynb; OSCAR_star_pattern_v2-adrien.ipynb; OSCAR_Ushant_L1b.ipynb 

This Pull Request closes #363 