### PR TITLE
Issue #396

### DIFF
--- a/seastar/gmfs/doppler.py
+++ b/seastar/gmfs/doppler.py
@@ -166,7 +166,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
                 aux_geo.OceanSurfaceWindSpeed.values,
                 relative_wind_direction.values,
                 L1.IncidenceAngleImage.values,
-                str(L1.Polarization.data),
+                L1.Polarization.data,
             )
         else:
             dop_c = np.full(L1.IncidenceAngleImage.shape, np.nan)
@@ -460,7 +460,7 @@ def mouche12(u10, phi, inc, pol):
     size = sizes.max()
     if ((sizes != size) & (sizes != 1)).any():
         raise Exception('Inputs sizes do not agree.')
-    valid_pol = {'VV','HH'}
+    valid_pol = ['VV','HH']
     if pol not in valid_pol:
         msg_err = f'Error, unknown polarisation: {pol}. Expected polarisation: {valid_pol}.'
         logger.error(msg_err)


### PR DESCRIPTION
Update to fix issue detailed in #396 

I'm unsure whether this is the best place to fix it permanently. In my mind the ideal place would be in `gmfs.doppler.mouche12` which currently only accepts `pol` information in string format. Suggestions welcome